### PR TITLE
Fixed Eclipse Leshan OBSERVE comaptibility bug

### DIFF
--- a/lib/coap-node.js
+++ b/lib/coap-node.js
@@ -730,8 +730,10 @@ CoapNode.prototype._enableReport = function (oid, iid, rid, rsp, callback) {
 
             val = cutils.encodeJson(key, rAttrs.lastRpVal);
         } else {
-            val = val.toString();
             rAttrs.lastRpVal = val;
+            // For Eclipse Leshan compatibility, the value should be sent 
+            // as TLV encoded instead of UTF
+            val = cutils.encodeTlv(key, val);
         }
 
         try {


### PR DESCRIPTION
Eclipse Leshan expects OBSERVE payload to be sent as TLV encoded, not UTF-8. 

Without this patch, Observe on client resources doesn't update and following logs were observed in Leshan 1.0.0.

Caused by: org.eclipse.leshan.tlv.TlvException: Impossible to parse TLV: 
3238
        at org.eclipse.leshan.tlv.TlvDecoder.decode(TlvDecoder.java:145) ~[leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.eclipse.leshan.core.node.codec.tlv.LwM2mNodeTlvDecoder.decode(LwM2mNodeTlvDecoder.java:51) ~[leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.eclipse.leshan.core.node.codec.DefaultLwM2mNodeDecoder.decodeTimestampedData(DefaultLwM2mNodeDecoder.java:96) ~[leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar:?]
        at org.eclipse.leshan.server.californium.impl.ObservationServiceImpl.createObserveResponse(ObservationServiceImpl.java:270) ~[leshan-server-demo-1.0.0-SNAPSHOT-jar-with-dependencies.jar:?]

Please check for the compatibiliy with Shephard. 
